### PR TITLE
Fix integer overflow on Windows

### DIFF
--- a/ptflops/flops_counter.py
+++ b/ptflops/flops_counter.py
@@ -316,9 +316,9 @@ def conv_flops_counter_hook(conv_module, input, output):
     groups = conv_module.groups
 
     filters_per_channel = out_channels // groups
-    conv_per_position_flops = np.prod(kernel_dims) * in_channels * filters_per_channel
+    conv_per_position_flops = int(np.prod(kernel_dims)) * in_channels * filters_per_channel
 
-    active_elements_count = batch_size * np.prod(output_dims)
+    active_elements_count = batch_size * int(np.prod(output_dims))
 
     overall_conv_flops = conv_per_position_flops * active_elements_count
 

--- a/ptflops/flops_counter.py
+++ b/ptflops/flops_counter.py
@@ -174,8 +174,7 @@ def compute_average_flops_cost(self):
     for module in self.modules():
         if is_supported_instance(module):
             flops_sum += module.__flops__
-            params_sum += module.__params__
-
+    params_sum = get_model_parameters_number(self)
     return flops_sum / batches_count, params_sum
 
 


### PR DESCRIPTION
Also now ptflops accounts parameters from all modules, not only from supported ones.