### PR TITLE
Add batch_first support in multihead_attention

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 readme = open('README.md').read()
 
-VERSION = '0.6.6'
+VERSION = '0.6.7'
 
 requirements = [
     'torch',


### PR DESCRIPTION
The prior implementation assumed that the `nn.MultiheadAttention` module would always have `batch_first=False`.
Here, we introduce a dynamic check to support batch_first.