### PR TITLE
Fix Mac count displayed for small networks.

### DIFF
--- a/ptflops/utils.py
+++ b/ptflops/utils.py
@@ -7,7 +7,7 @@ Copyright (C) 2021 Sovrasov V. - All Rights Reserved
 '''
 
 
-def flops_to_string(flops, units='GMac', precision=2):
+def flops_to_string(flops, units=None, precision=2):
     if units is None:
         if flops // 10**9 > 0:
             return str(round(flops / 10.**9, precision)) + ' GMac'


### PR DESCRIPTION
For smaller networks such as LeNet-5, the Mac count shows up as 0.00 GMac. The default parameter of `flops_to_string()`, `units` is thus changed to fix this. The output now displayed is 423.04 KMac for LeNet-5.